### PR TITLE
Make `bin` files windows safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha --reporter=spec test/*-test.js && npm run lint"
   },
   "bin": {
-    "ninja.js": "./bin/ninja.js"
+    "ninjajs": "./bin/ninja.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I assume also on POSIX you don't want a file named `*.js` in your global path
Fix #1